### PR TITLE
fix: peer certificate index out of range

### DIFF
--- a/exporter/ssl_chain_exporter.go
+++ b/exporter/ssl_chain_exporter.go
@@ -97,8 +97,8 @@ func (collector *sslChainCollector) Collect(ch chan<- prometheus.Metric) {
 
 func (collector *sslChainCollector) collect(conn *tls.Conn, opt SSLOption, ch chan<- prometheus.Metric) {
 	for id, chain := range peerCertificatesIndex {
-		expiry := conn.ConnectionState().PeerCertificates[id].NotAfter
-		issuer := fmt.Sprintf("%s", conn.ConnectionState().PeerCertificates[id].Issuer)
+		expiry := conn.ConnectionState().VerifiedChains[0][id].NotAfter
+		issuer := fmt.Sprintf("%s", conn.ConnectionState().VerifiedChains[0][id].Issuer)
 
 		ch <- prometheus.MustNewConstMetric(collector.expiry, prometheus.GaugeValue, float64(expiry.Unix()), opt.Domain, chain, issuer)
 	}


### PR DESCRIPTION
when trying to reach some domains,  sometimes delivered only two chains, therefore our program will stop immediately in the below error because the expected chain is 3.
![image](https://user-images.githubusercontent.com/16633179/200711545-8964ba73-6f48-49f8-a90b-ecc6ea9223c9.png)

so this main PR only extracts the available certificate chain from the collected domain
![image](https://user-images.githubusercontent.com/16633179/200712369-e6e2b9f7-aaa4-46dc-87e8-d493458d78d3.png)
